### PR TITLE
Add a convenience handler for logging configs.

### DIFF
--- a/udplog/test/test_udplog.py
+++ b/udplog/test/test_udplog.py
@@ -323,3 +323,36 @@ class UDPLogHandlerTest(unittest.TestCase):
         category, eventDict = self.udplogger.logged[-1]
         self.assertIn('foo', eventDict)
         self.assertEqual('bar', eventDict['foo'])
+
+
+
+class UDPLogHandlerFactoryTest(unittest.TestCase):
+    """
+    Tests for L{udplog.ConfigurableUDPLogHandler}.
+    """
+
+    def test_argsDefaults(self):
+        """
+        Without arguments, the logger and handler have their defaults.
+        """
+        handler = udplog.ConfigurableUDPLogHandler()
+        logger = handler.logger
+
+        self.assertEquals('python_logging', handler.category)
+        self.assertEquals(('127.0.0.1', 55647), logger.socket.getpeername())
+        self.assertEquals({'hostname': socket.gethostname()},
+                          logger.defaultFields)
+
+
+    def test_args(self):
+        """
+        All arguments are passed on.
+        """
+        handler = udplog.ConfigurableUDPLogHandler({'foo': 'bar'}, 'test',
+                                                   '10.0.0.1', 55648, False)
+        logger = handler.logger
+
+        self.assertEquals('test', handler.category)
+        self.assertEquals(('10.0.0.1', 55648), logger.socket.getpeername())
+        self.assertNotIn('hostname', logger.defaultFields)
+        self.assertEquals('bar', logger.defaultFields['foo'])

--- a/udplog/udplog.py
+++ b/udplog/udplog.py
@@ -252,6 +252,69 @@ class UDPLogHandler(logging.Handler):
 
 
 
+class ConfigurableUDPLogHandler(UDPLogHandler):
+    """
+    Configurable UDPLog logging handler.
+
+    This is a convenience subclass of UDPLogHandler for use in logging
+    configuration files (see L{logging.config.fileConfig})::
+
+        [loggers]
+        keys = root
+
+        [handlers]
+        keys = udplog
+
+        [formatters]
+        keys =
+
+        [logger_root]
+        level = INFO
+        handlers = udplog
+
+        [handler_udplog]
+        class = udplog.udplog.ConfigurableUDPLogHandler
+        level = INFO
+        args = ({'appname': 'example'},)
+
+    @note: This is a subclass instead of a factory function because
+        L{logging.config} requires this.
+    """
+
+
+    def __init__(self, defaultFields=None, category='python_logging',
+                       host=DEFAULT_HOST, port=DEFAULT_PORT,
+                       includeHostname=True):
+        """
+        Set up a UDPLogHandler with a UDPLogger.
+
+        @param defaultFields: Mapping of default fields to include in all
+            events.
+        @type defaultFields: L{dict}.
+
+        @param category: The UDPLog category.
+        @type category: L{bytes}.
+
+        @param host: The UDP host to send to.
+        @type host: L{bytes}.
+
+        @param port: The UDP port to send to.
+        @type host: L{int}.
+
+        @param includeHostname: If set, the default fields include a
+            C{'hostname'} field set to the current hostname.
+        @type includeHostname: L{bool}.
+        """
+        defaultFields = defaultFields or {}
+
+        if includeHostname:
+            defaultFields.setdefault('hostname', socket.gethostname())
+
+        logger = UDPLogger(host=host, port=port, defaultFields=defaultFields)
+        UDPLogHandler.__init__(self, logger, category)
+
+
+
 def main():
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.bind((DEFAULT_HOST, DEFAULT_PORT))


### PR DESCRIPTION
With the two staged set up and that constrained environment that logging config files, `ConfigurableUDPLogHandler`, a new convenience subclass of `UDPLogHandler`, makes it easier to include in existing logging configurations.
