### PR TITLE
Augment UDP send failure warning.

### DIFF
--- a/udplog/test/test_udplog.py
+++ b/udplog/test/test_udplog.py
@@ -72,7 +72,7 @@ class UDPLoggerTest(unittest.TestCase):
         If eventDict is not a dict, TypeError is raised.
         """
         logger = udplog.UDPLogger()
-        self.assertRaises(TypeError, logger.log, 'acategory', 1)
+        self.assertRaises(AttributeError, logger.log, 'acategory', 1)
 
 
     def test_logObjects(self):
@@ -197,6 +197,38 @@ class UDPLoggerTest(unittest.TestCase):
         self.assertRegexpMatches(
             sys.stderr.getvalue(),
             r'^Failed to send udplog message\n.*Message too long')
+
+
+    def test_logTooLongTimestamp(self):
+        """
+        If the log event is too long, the warning has a timestamp.
+        """
+        logger = udplog.UDPLogger()
+        self._catchOutput(logger)
+
+        logger.log('atest', {u'message': u'a' * self.MAX_DATAGRAM_SIZE,
+                             u'timestamp': 1357328823.75116})
+
+        self.assertEqual(1, len(self.output))
+        category, eventDict = udplog.unserialize(self.output[0])
+
+        self.assertIn('timestamp', eventDict)
+
+
+    def test_logTooLongDefault(self):
+        """
+        If the log event is too long, the warning has default fields.
+        """
+        logger = udplog.UDPLogger(defaultFields={'foo': 'bar'})
+        self._catchOutput(logger)
+
+        logger.log('atest', {u'message': u'a' * self.MAX_DATAGRAM_SIZE,
+                             u'timestamp': 1357328823.75116})
+
+        self.assertEqual(1, len(self.output))
+        category, eventDict = udplog.unserialize(self.output[0])
+
+        self.assertIn('foo', eventDict)
 
 
     def test_augmentTimestamp(self):

--- a/udplog/udplog.py
+++ b/udplog/udplog.py
@@ -98,11 +98,12 @@ class UDPLogger(object):
 
 
     def augment(self, eventDict):
-        newEventDict = {}
-        newEventDict.setdefault('timestamp', time.time())
-        newEventDict.update(self.defaultFields)
-        newEventDict.update(eventDict)
-        return newEventDict
+        """
+        Augment the event dictionary with timestamp and default fields.
+        """
+        eventDict.setdefault('timestamp', time.time())
+        for key, value in self.defaultFields.iteritems():
+            eventDict.setdefault(key, value)
 
 
     def serialize(self, category, eventDict):
@@ -155,6 +156,7 @@ class UDPLogger(object):
 
         newEventDict['original_size'] = size
 
+        self.augment(newEventDict)
         return self.serialize('udplog', newEventDict)
 
 
@@ -172,7 +174,7 @@ class UDPLogger(object):
             to a string before adding them to the event dictionary.
         @type eventDict: C{dict}
         """
-        eventDict = self.augment(eventDict)
+        self.augment(eventDict)
         data = self.serialize(category, eventDict)
 
         try:


### PR DESCRIPTION
If sending an event over UDP fails, the failure notice that is sent now
has a timestamp and default fields, just like the original. This makes
it easier to see where a failure event occured (e.g. when one of the
default fields is the hostname).

This also changes `augment` to modify the passed event dictionary
instead of starting a new one and copying over all values.
