### PR TITLE
Add syslog listener support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,7 @@ env:
 install:
   - pip install pyflakes --use-mirrors
   - pip install $TWISTED --use-mirrors
-  - pip install simplejson --use-mirrors
-  - pip install txAMQP --use-mirrors
-  - pip install txredis --use-mirrors
-  - pip install scribe --use-mirrors
-  - pip install thrift --use-mirrors
+  - pip install -e .
 
 script:
   - pyflakes udplog twisted

--- a/setup.py
+++ b/setup.py
@@ -63,5 +63,6 @@ setup(
         'txredis',
         'thrift',
         'scribe',
+        'python-dateutil',
     ],
 )

--- a/udplog/syslog.py
+++ b/udplog/syslog.py
@@ -1,0 +1,111 @@
+from __future__ import absolute_import
+
+import re
+
+from dateutil.parser import parse
+
+from twisted.python import log
+
+FACILITIES = [
+    u'kern', u'user', u'mail', u'daemon', u'auth', u'syslog', u'lpr', u'news',
+    u'uucp', u'cron', u'authpriv', u'ftp', u'ntp', u'audit', u'alert', u'at',
+    u'local0', u'local1', u'local2', u'local3', u'local4', u'local5',
+    u'local6', u'local7'
+    ]
+
+SEVERITIES = [
+    u'emerg', u'alert', u'crit', u'err', u'warn', u'notice', u'info', u'debug'
+    ]
+
+RE_SYSLOG = re.compile(
+    u"""
+    ^
+    <(?P<priority>\d+)>
+    (?P<timestamp>\w\w\w[ ][ 123456789]\d[ ]\d\d:\d\d:\d\d)[ ]
+    (?P<hostname>\w+)[ ]
+    (?P<tag>\w+)(\[(?P<pid>\d+)\])?:[ ]?
+    (?P<message>.*)
+    $
+    """,
+    re.IGNORECASE | re.VERBOSE)
+
+
+
+def parsePriority(priority):
+    """
+    Extract facility and severity from syslog priority.
+
+    @param priority: Syslog priority. Between 0 and 191.
+    @type priority: L{int}
+
+    @return: Tuple of facility and severity names. See L{FACILITIES} and
+        L{SEVERITIES}.
+    @rtype: L{tuple} of L{unicode}
+    """
+    facility, severity = divmod(priority, 8)
+    return FACILITIES[facility], SEVERITIES[severity]
+
+
+
+def parseSyslog(line, tzinfo):
+    """
+    Parse syslog log message.
+
+    This parses a syslog message per RFC 3164 into a dictionary with keys
+    {u'message'}, C{'timestamp'}, C{'facility'}, C{'severity'}, C{'hostname'},
+    C{'tag'} and C{'pid'}. If the log line doesn't match the syntax defined in
+    RFC 3164 it returns the entire line as the value of the C{'message'} key.
+
+    The syslog timestamp format only specifies month, day and time, lacking
+    year or timestamp information. L{dateutil} is used to fill in the blanks
+    using the C{tzinfo} parameter. Most likely you want to pass
+    L{dateutil.tz.gettz()} as the value, as this attempts to determine the
+    system's time zone (e.g. from C{/etc/localtime}), which is most likely the
+    same as the one used for logging the timezone-naive timestamps.
+
+    If the timestamp cannot be parsed, the C{'timestamp'} key will be absent
+    from the resulting dictionary. If there is no PID in square brackets
+    directly following the tag, the C{'pid'} key will be absent. If the
+    priority exceed 191, the C{'facility'} and C{'severity'} fields will be
+    empty.
+
+    @param line: Syslog log message.
+    @type line: C{unicode}
+
+    @param tzinfo: Timezone information to attach to syslog's timezone-naive
+        timestamps.
+    @type tzinfo: L{datetime.tzinfo}
+
+    @return: Event dictionary. The C{'timestamp'} key will have a
+        timezone-aware L{datetime.datetime} as value. All other values are
+        L{unicode} strings.
+
+    @rtype: L{dict}.
+    """
+    eventDict = {}
+
+    match = RE_SYSLOG.match(line)
+    if match:
+        facility, severity = parsePriority(int(match.group('priority')))
+        if facility:
+            eventDict['facility'] = facility
+        if severity:
+            eventDict['severity'] = severity
+
+        try:
+            dt = parse(match.group('timestamp'))
+        except ValueError:
+            log.err()
+        else:
+            dt = dt.replace(tzinfo=tzinfo)
+            eventDict['timestamp'] = dt
+
+        eventDict['hostname'] = match.group('hostname')
+        eventDict['tag'] = match.group('tag')
+        if match.group('pid'):
+            eventDict['pid'] = match.group('pid')
+        eventDict['message'] = match.group('message')
+    else:
+        eventDict['message'] = line
+
+    return eventDict

--- a/udplog/tap.py
+++ b/udplog/tap.py
@@ -37,6 +37,7 @@ class Options(usage.Options):
 
         ('syslog-interface', None, '', 'syslog interface'),
         ('syslog-port', None, None, 'syslog port', int),
+        ('syslog-unix-socket', None, None, 'syslog UNIX socket'),
         ]
 
     optFlags = [
@@ -74,14 +75,22 @@ def makeService(config):
     udplogServer.setServiceParent(s)
 
     # Set up syslog server
-    if config['syslog-port'] is not None:
+    if (config['syslog-port'] is not None or
+        config['syslog-unix-socket'] is not None):
         syslogProtocol = syslog.SyslogDatagramProtocol(dispatcher.eventReceived)
 
-        syslogServer = internet.UDPServer(port=config['syslog-port'],
-                                          protocol=syslogProtocol,
-                                          interface=config['syslog-interface'],
-                                          maxPacketSize=65536)
-        syslogServer.setServiceParent(s)
+        if config['syslog-unix-socket'] is not None:
+            syslogServer = internet.UNIXDatagramServer(
+                address=config['syslog-unix-socket'],
+                protocol=syslogProtocol,
+                maxPacketSize=65536)
+            syslogServer.setServiceParent(s)
+        if config['syslog-port'] is not None:
+            syslogServer = internet.UDPServer(port=config['syslog-port'],
+                                              protocol=syslogProtocol,
+                                              interface=config['syslog-interface'],
+                                              maxPacketSize=65536)
+            syslogServer.setServiceParent(s)
 
 
     # Set up Thrift/Scribe client.

--- a/udplog/tap.py
+++ b/udplog/tap.py
@@ -12,7 +12,7 @@ from twisted.application import service
 from twisted.application import internet
 from twisted.python import usage
 
-from udplog.twisted import DispatcherFromUDPLogProtocol
+from udplog.twisted import Dispatcher, UDPLogProtocol
 from udplog.twisted import UDPLogClientFactory
 from udplog.twisted import UDPLogToTwistedLog
 from udplog import udplog
@@ -57,10 +57,11 @@ def makeService(config):
     s = service.MultiService()
 
     # Set up UDP server as the dispatcher.
-    dispatcher = DispatcherFromUDPLogProtocol()
+    dispatcher = Dispatcher()
+    udplogProtocol = UDPLogProtocol(dispatcher.eventReceived)
 
     udplogServer = internet.UDPServer(port=config['udplog-port'],
-                                      protocol=dispatcher,
+                                      protocol=udplogProtocol,
                                       interface=config['udplog-interface'],
                                       maxPacketSize=65536)
     udplogServer.setServiceParent(s)

--- a/udplog/test/test_rabbitmq.py
+++ b/udplog/test/test_rabbitmq.py
@@ -113,7 +113,7 @@ class RabbitMQPublisherTest(unittest.TestCase):
         self.publisher.producer = twisted.QueueProducer(callback=cb,
                                                        clock=clock)
         self.publisher.producer.resumeProducing()
-        self.publisher.dispatcher = twisted.DispatcherFromUDPLogProtocol()
+        self.publisher.dispatcher = twisted.Dispatcher()
         self.publisher.dispatcher.register(self.publisher.producer.put)
 
         # Patch parent class to test up-call

--- a/udplog/test/test_redis.py
+++ b/udplog/test/test_redis.py
@@ -14,7 +14,7 @@ from twisted.internet import defer
 from twisted.trial import unittest
 
 from udplog import redis
-from udplog.twisted import DispatcherFromUDPLogProtocol
+from udplog.twisted import Dispatcher
 
 class FakeRedisClient(object):
 
@@ -34,7 +34,7 @@ class FakeRedisClient(object):
 class RedisPublisherServiceTest(unittest.TestCase):
 
     def setUp(self):
-        self.dispatcher = DispatcherFromUDPLogProtocol()
+        self.dispatcher = Dispatcher()
         self.client = FakeRedisClient()
         self.publisher = redis.RedisPublisher(self.dispatcher,
                                               self.client,
@@ -298,7 +298,7 @@ class MakeServiceTest(unittest.TestCase):
         config = {'redis-hosts': set(['10.0.0.2', '10.0.0.3']),
                   'redis-port': 6379,
                   'redis-key': 'udplog'}
-        dispatcher = DispatcherFromUDPLogProtocol()
+        dispatcher = Dispatcher()
         multiService = redis.makeService(config, dispatcher)
         services = list(multiService)
 

--- a/udplog/test/test_syslog.py
+++ b/udplog/test/test_syslog.py
@@ -1,0 +1,130 @@
+from dateutil import tz
+import datetime
+
+from twisted.trial.unittest import TestCase
+
+from udplog import syslog
+
+class ParsePriorityTests(TestCase):
+
+    def test_priority13(self):
+        self.assertEquals(('user', 'notice'), syslog.parsePriority(13))
+
+
+    def test_priority29(self):
+        self.assertEquals(('daemon', 'notice'), syslog.parsePriority(29))
+
+
+
+class ParseSyslogTests(TestCase):
+
+    def setUp(self):
+        self.tz = tz.gettz('Europe/Amsterdam')
+
+
+    def test_priority(self):
+        """
+        The priority is extracted and decoded into facility and severity.
+        """
+        line = "<13>Jan 15 16:59:26 myhost test: hello"
+        result = syslog.parseSyslog(line, self.tz)
+        self.assertEquals('user', result['facility'])
+        self.assertEquals('notice', result['severity'])
+
+
+    def test_message(self):
+        """
+        The message is extracted from the log line.
+        """
+        line = "<13>Jan 15 16:59:26 myhost test: hello"
+        result = syslog.parseSyslog(line, self.tz)
+        self.assertEquals('hello', result['message'])
+
+
+    def test_timestamp(self):
+        """
+        Timestamp is converted to a L{datetime} in the given timezone.
+        """
+        line = "<13>Jan 15 16:59:26 myhost test: hello"
+        result = syslog.parseSyslog(line, self.tz)
+        timestamp = datetime.datetime(2015, 1, 15, 15, 59, 26, tzinfo=tz.tzutc())
+        self.assertEquals(timestamp, result['timestamp'])
+
+
+    def test_timestampOtherZone(self):
+        """
+        Timestamp is converted to a L{datetime} in the other timezone.
+        """
+        line = "<13>Jan 15 16:59:26 myhost test: hello"
+        result = syslog.parseSyslog(line, tz.gettz('America/Los Angeles'))
+        timestamp = datetime.datetime(2015, 1, 16, 00, 59, 26, tzinfo=tz.tzutc())
+        self.assertEquals(timestamp, result['timestamp'])
+
+
+    def test_timestampSingleDigitDay(self):
+        """
+        Single digit days are parsed correctly.
+        """
+        line = "<13>Jan  5 16:59:26 myhost test: hello"
+        result = syslog.parseSyslog(line, self.tz)
+        timestamp = datetime.datetime(2015, 1, 5, 15, 59, 26, tzinfo=tz.tzutc())
+        self.assertEquals(timestamp, result['timestamp'])
+
+
+    def test_timestampInvalid(self):
+        """
+        Invalid dates result in no timestamp, error logged.
+        """
+        line = "<13>Foo 15 16:59:26 myhost test: hello"
+        result = syslog.parseSyslog(line, self.tz)
+        self.assertNotIn('timestamp', result)
+        self.assertEqual(1, len(self.flushLoggedErrors(ValueError)))
+
+
+    def test_hostname(self):
+        """
+        The hostname is extracted.
+        """
+        line = "<13>Jan 15 16:59:26 myhost test: hello"
+        result = syslog.parseSyslog(line, self.tz)
+        self.assertEquals('myhost', result['hostname'])
+
+
+    def test_tag(self):
+        """
+        The tag is extracted.
+        """
+        line = "<13>Jan 15 16:59:26 myhost test: hello"
+        result = syslog.parseSyslog(line, self.tz)
+        self.assertEquals('test', result['tag'])
+
+
+    def test_tagFollowedByPID(self):
+        """
+        If a tag is followed by a PID, the PID is not included.
+        """
+        line = ("<29>Jan 16 15:08:58 myhost wpa_supplicant[1432]: "
+                "wlan0: CTRL-EVENT-SCAN-STARTED ")
+        result = syslog.parseSyslog(line, self.tz)
+        self.assertEquals('wpa_supplicant', result['tag'])
+
+
+    def test_pid(self):
+        """
+        The optional PID is extracted.
+        """
+        line = ("<29>Jan 16 15:08:58 myhost wpa_supplicant[1432]: "
+                "wlan0: CTRL-EVENT-SCAN-STARTED ")
+        result = syslog.parseSyslog(line, self.tz)
+        self.assertEquals('1432', result['pid'])
+        self.assertEquals('wlan0: CTRL-EVENT-SCAN-STARTED ',
+                          result['message'])
+
+
+    def test_invalidFormat(self):
+        """
+        If the log line cannot be parsed, it is returned as the message.
+        """
+        line = "something"
+        result = syslog.parseSyslog(line, self.tz)
+        self.assertEquals('something', result['message'])

--- a/udplog/test/test_syslog.py
+++ b/udplog/test/test_syslog.py
@@ -1,3 +1,12 @@
+# Copyright (c) Ralph Meijer.
+# See LICENSE for details.
+
+"""
+Tests for L{udplog.syslog}.
+"""
+
+from __future__ import division, absolute_import
+
 from dateutil import tz
 import datetime
 
@@ -6,17 +15,43 @@ from twisted.trial.unittest import TestCase
 from udplog import syslog
 
 class ParsePriorityTests(TestCase):
+    """
+    Tests for L{syslog.parsePriority}.
+    """
 
     def test_priority13(self):
+        """
+        Priority of 13 means facility user, severity notice.
+        """
         self.assertEquals(('user', 'notice'), syslog.parsePriority(13))
 
 
     def test_priority29(self):
+        """
+        Priority of 29 means facility daemon, severity notice.
+        """
         self.assertEquals(('daemon', 'notice'), syslog.parsePriority(29))
+
+
+    def test_priority191(self):
+        """
+        191 is the highest valid priority value.
+        """
+        self.assertEquals(('local7', 'debug'), syslog.parsePriority(191))
+
+
+    def test_priority192(self):
+        """
+        Priority cannot exceed 191.
+        """
+        self.assertRaises(IndexError, syslog.parsePriority, 192)
 
 
 
 class ParseSyslogTests(TestCase):
+    """
+    Tests for L{syslog.parseSyslog}.
+    """
 
     def setUp(self):
         self.tz = tz.gettz('Europe/Amsterdam')
@@ -30,6 +65,16 @@ class ParseSyslogTests(TestCase):
         result = syslog.parseSyslog(line, self.tz)
         self.assertEquals('user', result['facility'])
         self.assertEquals('notice', result['severity'])
+
+
+    def test_priorityInvalid(self):
+        """
+        The C{'facility'} and C{'severity'} are omitted for invalid priorities.
+        """
+        line = "<192>Jan 15 16:59:26 myhost test: hello"
+        result = syslog.parseSyslog(line, self.tz)
+        self.assertNotIn('facility', result)
+        self.assertNotIn('severity', result)
 
 
     def test_message(self):

--- a/udplog/test/test_twisted.py
+++ b/udplog/test/test_twisted.py
@@ -235,15 +235,14 @@ class TwistedLogHandlerTest(unittest.TestCase):
 
 
 
-class UDPLogProtocol(unittest.TestCase):
+class UDPLogProtocolTest(unittest.TestCase):
     """
     Tests for L{udplog.twisted.UDPLogProtocol}.
     """
 
     def setUp(self):
         self.events = []
-        self.protocol = twisted.UDPLogProtocol()
-        self.protocol.eventReceived = self.events.append
+        self.protocol = twisted.UDPLogProtocol(self.events.append)
 
 
     def test_datagramReceived(self):
@@ -288,13 +287,13 @@ class UDPLogProtocol(unittest.TestCase):
 
 
 
-class DispatcherFromUDPLogProtocolTest(unittest.TestCase):
+class Dispatcher(unittest.TestCase):
     """
-    Tests for L{udplog.twisted.DispatcherFromUDPLogProtocol}.
+    Tests for L{udplog.twisted.Dispatcher}.
     """
 
     def setUp(self):
-        self.dispatcher = twisted.DispatcherFromUDPLogProtocol()
+        self.dispatcher = twisted.Dispatcher()
 
 
     def test_register(self):

--- a/udplog/twisted.py
+++ b/udplog/twisted.py
@@ -183,6 +183,9 @@ class UDPLogProtocol(protocol.DatagramProtocol):
     an event, it is decoded and passed to L{eventReceived}.
     """
 
+    def __init__(self, callback):
+        self.callback = callback
+
     def datagramReceived(self, datagram, addr):
         data = datagram.rstrip()
 
@@ -193,19 +196,10 @@ class UDPLogProtocol(protocol.DatagramProtocol):
             log.err()
             return
 
-        self.eventReceived(event)
+        self.callback(event)
 
 
-    def eventReceived(self, event):
-        """
-        A log event was received.
-
-        Override this method to process events.
-        """
-
-
-
-class DispatcherFromUDPLogProtocol(UDPLogProtocol):
+class Dispatcher(object):
     """
     Adapter from UDPLogProtocol to a consumer of log events.
     """
@@ -386,7 +380,7 @@ class UDPLogClientFactory(protocol.ReconnectingClientFactory):
 
 class UDPLogToTwistedLog(object):
     """
-    Consumer for L{DispatcherFromUDPLogProtocol} that logs to Twisted log.
+    Consumer for L{Dispatcher} that logs to Twisted log.
     """
 
     def __init__(self, dispatcher):

--- a/udplog/twisted.py
+++ b/udplog/twisted.py
@@ -1,4 +1,4 @@
-# -*- test-case-name: udplog.test.test_scribe -*-
+# -*- test-case-name: udplog.test.test_twisted -*-
 #
 # Copyright (c) Mochi Media, Inc.
 # Copyright (c) Ralph Meijer.


### PR DESCRIPTION
This adds support for receiving syslog (RFC 3164) message over UDP or UNIX datagram socket, and having the received events dispatched as if received using the native udplog protocol.